### PR TITLE
fix(react): add the required parserOption 'jsx'

### DIFF
--- a/src/components/react/index.ts
+++ b/src/components/react/index.ts
@@ -10,6 +10,11 @@ module.exports = {
       { name: 'Link', linkAttribute: 'to' },
     ],
   },
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
   extends: [
     './best-practices',
     './possible-errors',


### PR DESCRIPTION
To support vanilla .jsx files, the parserOption ecmaFeatures.jsx must be set to true. Otherwise,
ESLint will not be able to parse the JSX syntax.