### PR TITLE
fix: add missing jest.js entrypoint

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/configs/jest');


### PR DESCRIPTION
This is required to extend `principled/jest`.